### PR TITLE
Add RedirectURL to OAuth2 config

### DIFF
--- a/fitbit.go
+++ b/fitbit.go
@@ -87,6 +87,7 @@ func New(config Config) *Session {
 	oAuthConfig := &oauth2.Config{
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
+		RedirectURL:  config.RedirectURL,
 		Scopes:       config.Scopes,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  fitbitAuthURL,


### PR DESCRIPTION
Redirect URI from config not passed into OAuth2 config resulting in the following error when attempting to go through the auth flow

```
Developer information: invalid_request - Missing redirect_uri parameter value
```

This PR:
- Add RedirectURL to OAuth2 config

This has been tested on locally running server