### PR TITLE
Handle errors from fitbit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ __debug_bin
 
 # my token
 /example/server/token.json
+
+# jetbrains IDE files
+.idea


### PR DESCRIPTION
The current code fails to handle some errors from fitbit.  For example, if the content returned is:

``` json
{
  "error":{
    "code": 429,
    "message": "Resource has been exhausted (e.g. check quota).",
    "status": "RESOURCE_EXHAUSTED"
  }
}
```
(indicating too many accesses have been attempted in too short a time - seen often during debugging)

This content generates no error in the code and an incomplete structure (depending on API call attempted) is passed back to the caller.

This PR adds a small check in Session.makeRequest to check for this scenario and returns an appropriate error